### PR TITLE
Fix container engine to use podman

### DIFF
--- a/ansible-navigator.yml
+++ b/ansible-navigator.yml
@@ -6,7 +6,7 @@ ansible-navigator:
 
   execution-environment:
     enabled: true
-    container-engine: docker
+    container-engine: podman
     pull-policy: missing
 
   logging:


### PR DESCRIPTION
In a rhel 8.5 by default running this configuration (with docker instead of podman) with ansible-navigator shows the following error : 
```
$ ansible-navigator run -m stdout -i /etc/ansible/hosts --eei ee_multi_tier:0.0.1 --pp never ping.yml
[ERROR]: Command provided: 'run -m stdout -i /etc/ansible/hosts --eei ee_multi_tier:0.0.1 --pp never ping.yml'
[ERROR]: The specified container engine could not be found: 'docker', set by 'user provided configuration file'
 [HINT]: Try installing 'docker', try again with '--ce auto' or '--ce podman' or even '--ee false' to disable the use of an execution environment
[ERROR]: Configuration failed, using default log file location: /home/devops/ansible_execution_environment_utilities/ansible-navigator.log. Log level set to debug
 [HINT]: Review the hints and log file to see what went wrong: /home/devops/ansible_execution_environment_utilities/ansible-navigator.log
```
